### PR TITLE
New bylaws patch, fix SetCursorPos and keyboard and enable xinput/xinput2

### DIFF
--- a/android/patches/dlls_winex11_drv_keyboard_c.patch
+++ b/android/patches/dlls_winex11_drv_keyboard_c.patch
@@ -1,0 +1,116 @@
+diff --git a/dlls/winex11.drv/keyboard.c b/dlls/winex11.drv/keyboard.c
+index 0456d819bc8..31e2d51c841 100644
+--- a/dlls/winex11.drv/keyboard.c
++++ b/dlls/winex11.drv/keyboard.c
+@@ -34,7 +34,6 @@
+ #include <X11/Xlib.h>
+ #include <X11/Xresource.h>
+ #include <X11/Xutil.h>
+-#include <X11/XKBlib.h>
+ 
+ #include <ctype.h>
+ #include <stdarg.h>
+@@ -62,6 +61,7 @@ WINE_DECLARE_DEBUG_CHANNEL(key);
+ static const unsigned int ControlMask = 1 << 2;
+ 
+ static int min_keycode, max_keycode, keysyms_per_keycode;
++static KeySym *key_mapping;
+ static WORD keyc2vkey[256], keyc2scan[256];
+ 
+ static int NumLockMask, ScrollLockMask, AltGrMask; /* mask in the XKeyEvent state */
+@@ -1093,6 +1093,11 @@ static const WORD xfree86_vendor_key_vkey[256] =
+     0, 0, 0, 0, 0, 0, 0, 0                                      /* 1008FFF8 */
+ };
+ 
++static inline KeySym keycode_to_keysym( Display *display, KeyCode keycode, int index )
++{
++    return key_mapping[(keycode - min_keycode) * keysyms_per_keycode + index];
++}
++
+ /* Returns the Windows virtual key code associated with the X event <e> */
+ /* kbd_section must be held */
+ static WORD EVENT_event_to_vkey( XIC xic, XKeyEvent *e)
+@@ -1493,21 +1498,8 @@ X11DRV_KEYBOARD_DetectLayout( Display *display )
+   for (keyc = min_keycode; keyc <= max_keycode; keyc++) {
+       /* get data for keycode from X server */
+       for (i = 0; i < syms; i++) {
+-        if (!(keysym = XkbKeycodeToKeysym( display, keyc, 0, i ))) continue;
++        if (!(keysym = keycode_to_keysym( display, keyc, i ))) continue;
+         ckey[keyc][i] = keysym_to_char(keysym);
+-        if (TRACE_ON(keyboard))
+-        {
+-            char buf[32];
+-            WCHAR bufW[32];
+-            int len, lenW;
+-            KeySym orig_keysym = keysym;
+-            len = XkbTranslateKeySym(display, &keysym, 0, buf, sizeof(buf), NULL);
+-            lenW = ntdll_umbstowcs(buf, len, bufW, ARRAY_SIZE(bufW));
+-            if (lenW < ARRAY_SIZE(bufW))
+-                bufW[lenW] = 0;
+-            TRACE("keycode %u, index %d, orig_keysym 0x%04lx, keysym 0x%04lx, buf %s, bufW %s\n",
+-                    keyc, i, orig_keysym, keysym, debugstr_a(buf), debugstr_w(bufW));
+-        }
+       }
+   }
+ 
+@@ -1610,7 +1602,8 @@ void X11DRV_InitKeyboard( Display *display )
+ 
+     pthread_mutex_lock( &kbd_mutex );
+     XDisplayKeycodes(display, &min_keycode, &max_keycode);
+-    XFree( XGetKeyboardMapping( display, min_keycode, max_keycode + 1 - min_keycode, &keysyms_per_keycode ) );
++    if (key_mapping) XFree( key_mapping );
++    key_mapping = XGetKeyboardMapping( display, min_keycode, max_keycode + 1 - min_keycode, &keysyms_per_keycode );
+ 
+     mmp = XGetModifierMapping(display);
+     kcp = mmp->modifiermap;
+@@ -1624,12 +1617,12 @@ void X11DRV_InitKeyboard( Display *display )
+ 		int k;
+ 
+ 		for (k = 0; k < keysyms_per_keycode; k += 1)
+-                    if (XkbKeycodeToKeysym( display, *kcp, 0, k ) == XK_Num_Lock)
++                    if (keycode_to_keysym( display, *kcp, k ) == XK_Num_Lock)
+ 		    {
+                         NumLockMask = 1 << i;
+                         TRACE_(key)("NumLockMask is %x\n", NumLockMask);
+ 		    }
+-                    else if (XkbKeycodeToKeysym( display, *kcp, 0, k ) == XK_Scroll_Lock)
++                    else if (keycode_to_keysym( display, *kcp, k ) == XK_Scroll_Lock)
+ 		    {
+                         ScrollLockMask = 1 << i;
+                         TRACE_(key)("ScrollLockMask is %x\n", ScrollLockMask);
+@@ -1681,7 +1674,7 @@ void X11DRV_InitKeyboard( Display *display )
+ 	      /* we seem to need to search the layout-dependent scancodes */
+ 	      int maxlen=0,maxval=-1,ok;
+ 	      for (i=0; i<syms; i++) {
+-    keysym = XkbKeycodeToKeysym( display, keyc, 0, i );
++    keysym = keycode_to_keysym( display, keyc, i );
+                 ckey[i] = keysym_to_char(keysym);
+ 	      }
+ 	      /* find key with longest match streak */
+@@ -1819,7 +1812,7 @@ void X11DRV_InitKeyboard( Display *display )
+     for (scan = 0x60, keyc = min_keycode; keyc <= max_keycode; keyc++)
+       if (keyc2vkey[keyc]&&!keyc2scan[keyc]) {
+ 	const char *ksname;
+-	keysym = XkbKeycodeToKeysym( display, keyc, 0, 0 );
++	keysym = keycode_to_keysym( display, keyc, 0 );
+ 	ksname = XKeysymToString(keysym);
+ 	if (!ksname) ksname = "NoSymbol";
+ 
+@@ -1941,7 +1934,7 @@ SHORT X11DRV_VkKeyScanEx( WCHAR wChar, HKL hkl )
+     }
+ 
+     for (index = 0; index < 4; index++) /* find shift state */
+-        if (XkbKeycodeToKeysym( display, keycode, 0, index ) == keysym) break;
++        if (keycode_to_keysym( display, keycode, index ) == keysym) break;
+ 
+     pthread_mutex_unlock( &kbd_mutex );
+ 
+@@ -2191,7 +2184,7 @@ INT X11DRV_GetKeyNameText( LONG lParam, LPWSTR lpBuffer, INT nSize )
+       INT rc;
+ 
+       keyc = (KeyCode) keyi;
+-      keys = XkbKeycodeToKeysym( display, keyc, 0, 0 );
++      keys = keycode_to_keysym( display, keyc, 0 );
+       name = XKeysymToString(keys);
+ 
+       if (name && (vkey == VK_SHIFT || vkey == VK_CONTROL || vkey == VK_MENU))

--- a/android/patches/dlls_winex11_drv_mouse_c.patch
+++ b/android/patches/dlls_winex11_drv_mouse_c.patch
@@ -1,17 +1,21 @@
 diff --git a/dlls/winex11.drv/mouse.c b/dlls/winex11.drv/mouse.c
-index 2ba4960..74cdb87 100644
+index 2ba49607bd2..c4e0b8c4e31 100644
 --- a/dlls/winex11.drv/mouse.c
 +++ b/dlls/winex11.drv/mouse.c
-@@ -1488,10 +1488,14 @@ BOOL X11DRV_SetCursorPos( INT x, INT y )
+@@ -1488,10 +1488,18 @@ BOOL X11DRV_SetCursorPos( INT x, INT y )
          return FALSE;
      }
  
-+#ifndef __ANDROID__
++#ifdef __ANDROID__
++    XNoOp( data->display );
++#else
      pXFixesHideCursor( data->display, root_window );
 +#endif
      XWarpPointer( data->display, root_window, root_window, 0, 0, 0, 0, pos.x, pos.y );
      data->warp_serial = NextRequest( data->display );
-+#ifndef __ANDROID__
++#ifdef __ANDROID__
++    XNoOp( data->display );
++#else
      pXFixesShowCursor( data->display, root_window );
 +#endif
      XFlush( data->display ); /* avoids bad mouse lag in games that do their own mouse warping */

--- a/android/patches/test-bylaws/dlls_ntdll_signal_arm64ec_c.patch
+++ b/android/patches/test-bylaws/dlls_ntdll_signal_arm64ec_c.patch
@@ -1,5 +1,5 @@
 diff --git a/dlls/ntdll/signal_arm64ec.c b/dlls/ntdll/signal_arm64ec.c
-index 061c9a6..4d5e4d3 100644
+index 061c9a66680..10cc7c4793f 100644
 --- a/dlls/ntdll/signal_arm64ec.c
 +++ b/dlls/ntdll/signal_arm64ec.c
 @@ -36,6 +36,11 @@
@@ -92,6 +92,15 @@ index 061c9a6..4d5e4d3 100644
  }
  __ASM_GLOBAL_FUNC( "#KiUserApcDispatcher",
                     ".seh_context\n\t"
+@@ -1593,7 +1607,7 @@ void CDECL RtlRestoreContext( CONTEXT *context, EXCEPTION_RECORD *rec )
+     }
+ 
+     /* hack: remove no longer accessible TEB frames */
+-    while ((ULONG64)teb_frame < context->Rsp)
++    while (is_valid_frame( (ULONG_PTR)teb_frame ) && (ULONG64)teb_frame < context->Rsp)
+     {
+         TRACE( "removing TEB frame: %p\n", teb_frame );
+         teb_frame = __wine_pop_frame( teb_frame );
 @@ -1788,6 +1802,14 @@ BOOLEAN WINAPI RtlIsProcessorFeaturePresent( UINT feature )
      return emulated_processor_features[feature];
  }
@@ -118,7 +127,7 @@ index 061c9a6..4d5e4d3 100644
  
      if (!__os_arm64x_check_call)
      {
-@@ -2080,10 +2104,10 @@ void WINAPI LdrInitializeThunk( CONTEXT *arm_context, ULONG_PTR unk2, ULONG_PTR 
+@@ -2080,10 +2104,10 @@ void WINAPI LdrInitializeThunk( CONTEXT *arm_context, ULONG_PTR unk2, ULONG_PTR
          __os_arm64x_set_x64_information = LdrpSetX64Information;
      }
  

--- a/build-scripts/build-step-arm64ec.sh
+++ b/build-scripts/build-step-arm64ec.sh
@@ -126,8 +126,6 @@ do
       --without-xcursor \
       --without-xfixes \
       --without-xinerama \
-      --without-xinput \
-      --without-xinput2 \
       --without-xrandr \
       --without-xrender \
       --without-xshape \
@@ -159,6 +157,7 @@ do
       "dlls_winex11_drv_desktop_c.patch"
       "dlls_winex11_drv_mouse_c.patch"
       "dlls_winex11_drv_window_c.patch"
+      "dlls_winex11_drv_keyboard_c.patch"
       "dlls_winex11_drv_x11drv_main_c.patch"
 
       # address space patches

--- a/build-scripts/build-step-x86_64.sh
+++ b/build-scripts/build-step-x86_64.sh
@@ -126,8 +126,6 @@ do
       --without-xcursor \
       --without-xfixes \
       --without-xinerama \
-      --without-xinput \
-      --without-xinput2 \
       --without-xrandr \
       --without-xrender \
       --without-xshape \
@@ -159,6 +157,7 @@ do
       "dlls_winex11_drv_desktop_c.patch"
       "dlls_winex11_drv_mouse_c.patch"
       "dlls_winex11_drv_window_c.patch"
+      "dlls_winex11_drv_keyboard_c.patch"
       "dlls_winex11_drv_x11drv_main_c.patch"
 
       # address space patches


### PR DESCRIPTION
To fix mouse in games that call `SetCursorPos` we need to call `XNoOp` so the sequence number is iterated on X server
That would normally be the case if we didn't skip the XFixes calls

The keyboard fix is from pipetto-crypto repo, it replaces calls to `XKeyboard` extension to calls to `GetKeyboardMapping` which is implemented on GameNative X server

New bylaws small patch fixes certain games that would crash silently on arm64ec build

Since XInput2 extension is implemented on GameNative X server we can enable it