### PR TITLE
fix OpenGL workaround initialization

### DIFF
--- a/android/patches/dlls_winex11_drv_opengl_c.patch
+++ b/android/patches/dlls_winex11_drv_opengl_c.patch
@@ -1,5 +1,5 @@
 diff --git a/dlls/winex11.drv/opengl.c b/dlls/winex11.drv/opengl.c
-index 478e3c2..b0619f8 100644
+index 478e3c253e5..1c98f14fe8e 100644
 --- a/dlls/winex11.drv/opengl.c
 +++ b/dlls/winex11.drv/opengl.c
 @@ -664,6 +664,9 @@ static void *opengl_handle;
@@ -12,13 +12,14 @@ index 478e3c2..b0619f8 100644
      unsigned int i;
  
      /* No need to load any other libraries as according to the ABI, libGL should be self-sufficient
-@@ -811,7 +814,14 @@ static void init_opengl(void)
+@@ -811,7 +814,15 @@ static void init_opengl(void)
  
      if(!X11DRV_WineGL_InitOpenglInfo()) goto failed;
  
 +#ifdef __ANDROID__
-+    if (getenv("WINE_X11FORCEGLX"))
-+        wine_x11forceglx = atoi("WINE_X11FORCEGLX");
++    const char *val = getenv("WINE_X11FORCEGLX");
++    if (val)
++        wine_x11forceglx = atoi(val);
 +
 +    if (XQueryExtension( gdi_display, "GLX", &glx_opcode, &event_base, &error_base ) || wine_x11forceglx)
 +#else


### PR DESCRIPTION
previous code don't actually check WINE_X11FORCEGLX environment variable value